### PR TITLE
specifying gradio version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ torchmetrics==0.6.0 \
 kornia==0.6 \
 pytorch-lightning==1.4.2 \
 invisible-watermark \
-gradio \
+gradio==3.2.1b2 \
 accelerate \
 transformers \
 pynvml==11.4.1 


### PR DESCRIPTION
specify gradio version to fix javascript error when selecting mask

in reference to the issue:

Javascript error when selecting Mask Image editor mode #3

specifying the gradio version fixed the issue for me